### PR TITLE
Add options for lexicons and text type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,12 @@ Options:
 * `--access-key KEY` -- AWS access key ID
 * `--ffmpeg BINARY` -- Path to the ffmpeg binary (defaults to the one in PATH)
 * `--format FORMAT` -- Target audio format (`mp3`, `ogg_vorbis`, or `pcm`) (default `mp3`)
+* `--lexicon NAME` -- Apply a stored pronunciation lexicon. Can be specified multiple times.
 * `--region REGION` -- AWS region to send requests to (default `us-east-1`)
 * `--sample-rate RATE` -- Audio frequency, in hertz. See the [API docs](http://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html#polly-SynthesizeSpeech-request-SampleRate) for valid values.
 * `--secret-key KEY` -- AWS secret access key
 * `--throttle SIZE` -- Number of simultaneous requests allowed against the AWS API (default `5`)
+* `--type TYPE` -- Type of input text (`text` or `ssml`) (default `text`)
 * `--voice VOICE` -- Voice to use for the speech (default `Joanna`). See the [API docs](http://docs.aws.amazon.com/polly/latest/dg/API_SynthesizeSpeech.html#polly-SynthesizeSpeech-request-VoiceId) for the full list of voices. You can also [test out the voices](https://console.aws.amazon.com/polly/home/SynthesizeSpeech) in the AWS console.
 
 ## What It Does

--- a/lib.js
+++ b/lib.js
@@ -43,10 +43,12 @@ Options:
   --access-key KEY    AWS access key ID
   --ffmpeg BINARY     Path to the ffmpeg binary (defaults to the one in PATH)
   --format FORMAT     Target audio format ("mp3", "ogg_vorbis", or "pcm") (default "mp3")
+  --lexicon NAME      Apply a stored pronunciation lexicon. Can be specified multiple times.
   --region REGION     AWS region to send requests to (default "us-east-1")
   --sample-rate RATE  Audio frequency, in hertz.
   --secret-key KEY    AWS secret access key
   --throttle SIZE     Number of simultaneous requests allowed against the AWS API (default 5)
+  --type TYPE         Type of input text ("text" or "ssml") (default "text")
   --voice VOICE       Voice to use for the speech (default "Joanna")
 `;
   if (args.help) {
@@ -78,9 +80,11 @@ let callAws = (info, i, callback) => {
   spinner.text = spinner.text.replace(/\d+\//, `${i}/`);
 
   let url = info.urlcreator({
+    LexiconNames: info.opts.lexicon,
     OutputFormat: info.opts.format,
     SampleRate: info.opts['sample-rate'] ? String(info.opts['sample-rate']) : undefined,
     Text: info.text,
+    TextType: info.opts.type,
     VoiceId: info.opts.voice
   }, halfHour);
 
@@ -213,12 +217,17 @@ exports.generateSpeech = (strParts, opts) => {
     'access-key': opts.accessKey,
     ffmpeg: opts.ffmpeg || 'ffmpeg',
     format: opts.format || 'mp3',
+    lexicon: opts.lexicon,
     limit: Number(opts.throttle) || 5, // eslint-disable-line no-magic-numbers
     region: opts.region || 'us-east-1',
     'sample-rate': opts.sampleRate,
     'secret-key': opts.secretKey,
+    type: opts.type || 'text',
     voice: opts.voice || 'Joanna'
   }, opts);
+  if (typeof opts.lexicon !== 'undefined' && !Array.isArray(opts.lexicon)) {
+    opts.lexicon = [opts.lexicon];
+  }
 
   let polly = createPolly(opts);
 

--- a/test/callaws.spec.js
+++ b/test/callaws.spec.js
@@ -12,7 +12,9 @@ describe('callAws()', () => {
       index: 6,
       opts: {
         format: 'ogg',
+        lexicon: ['lexicon1', 'lexicon2'],
         'sample-rate': 16000,
+        type: 'ssml',
         voice: 'John',
       },
       text: 'hello world',
@@ -64,6 +66,31 @@ describe('callAws()', () => {
     callAws(info, 0, () => {
       let opts = urlCreator.calls.mostRecent().args[0];
       expect(opts.SampleRate).toBe(String(testData.opts['sample-rate']));
+      done();
+    });
+  });
+
+  it('should not use lexicon names if not specified', done => {
+    delete info.opts.lexicon;
+    callAws(info, 0, () => {
+      let opts = urlCreator.calls.mostRecent().args[0];
+      expect(opts.LexiconNames).toBeUndefined();
+      done();
+    });
+  });
+
+  it('should use the lexicon names, when specified', done => {
+    callAws(info, 0, () => {
+      let opts = urlCreator.calls.mostRecent().args[0];
+      expect(opts.LexiconNames).toEqual(testData.opts.lexicon);
+      done();
+    });
+  });
+
+  it('should use the given text type', done => {
+    callAws(info, 0, () => {
+      let opts = urlCreator.calls.mostRecent().args[0];
+      expect(opts.TextType).toBe(testData.opts.type);
       done();
     });
   });


### PR DESCRIPTION
Adds support for a couple AWS Polly parameters:

* `--lexicon` can be used one or more times to specify stored lexicons. Passed to AWS as `LexiconNames`.
* `--type` can be used to specify the text type (`text` or `ssml`). Passed to AWS as `TextType`.

Resolves #15 