### PR TITLE
Limit GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  id-token: read
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Fixes https://github.com/eheikes/tts/security/code-scanning/1